### PR TITLE
Remove IsCallable check for constructor

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -25,12 +25,9 @@ markEffects: true
       <h1>Properties of the Error Constructor</h1>
 
       <emu-clause id="sec-error.capturestacktrace">
-        <h1>Error.captureStackTrace ( _error_ [ , _constructor_ ])</h1>
+        <h1>Error.captureStackTrace ( _error_ [ , _constructor_ ] )</h1>
         <emu-alg>
           1. If _error_ is not an Object, throw a *TypeError* exception.
-          1. If _constructor_ is not *undefined*, then
-            1. If IsCallable(_constructor_) is *false*, throw a *TypeError* exception.
-            1. TODO: No implementations currently check that _constructor_ is callable, this may not be web compatible.
           1. If IsCallable(_constructor_) is *true*, then
             1. Let _string_ be an implementation-defined string that represents the current stack trace, with all stack
                frames above the topmost call to _constructor_, including that call, omitted from the stack trace.


### PR DESCRIPTION
From my initial telemetry, I think requiring IsCallable(_constructor_) when the optional _constructor_ argument is present will be web compatible, but I don't have a strong opinion about whether it's worth the bother. Setting up this PR in case we decide to remove this check.