### PR TITLE
Fix use of SetterThatIgnoresPrototypeProperties

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -34,7 +34,7 @@ markEffects: true
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, _error_, *"stack"*, _string_).
+          1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
The first argument is the object to be manipulated, and the second is an object that rejects such manipulation (used to avoid overwriting setters on prototype objects that use SetterThatIgnoresPrototypeProperties, but irrelevant here).

Alternatively, SetterThatIgnoresPrototypeProperties could be refactored to make the _home_ parameter optional.