### PR TITLE
Allow implementation-defined choice of property or accessor

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -60,7 +60,8 @@ markEffects: true
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Let _strategy_ be the value of the [[ErrorCaptureStackTraceStrategy]] field of the current Realm Record.
+          1. Let _realm_ be the current Realm Record.
+          1. Let _strategy_ be _realm_.[[ErrorCaptureStackTraceStrategy]].
           1. If _strategy_ is ~data-property~, then
             1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
           1. Else,

--- a/spec.emu
+++ b/spec.emu
@@ -68,9 +68,13 @@ markEffects: true
             1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
           1. Else,
             1. If ? IsExtensible( _error_ ) is *false*, throw a *TypeError* exception.
-            1. Let _name_ be an implementation-defined name.
-            1. ! PrivateFieldAdd( _error_, _name_, _string_).
-            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: ? PrivateGet( _error_, _name_ ), [[Set]]: ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)., [[Enumerable]]: false, [[Configurable]]: true }).
+            1. Let getterClosure be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
+              1. Return NormalCompletion(_string_).
+            1. Let getter be CreateBuiltinFunction(getterClosure, 0, "", « »).
+            1. Let setterClosure be a new Abstract Closure with parameters (_value_) that captures _error_ and performs the following steps when called:
+              1. Perform ! SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _value_).
+            1. Let setter be CreateBuiltinFunction(setterClosure, 1, "", « »).
+            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: getter, [[Set]]: setter, [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -15,6 +15,35 @@ markEffects: true
   <p></p>
 </emu-intro>
 
+<emu-clause id="sec-agents">
+  <h1>Agents</h1>
+
+  <emu-table id="table-agent-record" caption="Agent Record Fields">
+    <table>
+      <thead>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tr>
+        <td>[[UseErrorCaptureStackTraceDataProperty]]</td>
+        <td>a Boolean</td>
+        <td>Whether to use a data property or an accessor property for the "stack" property installed by Error.captureStackTrace.</td>
+      </tr>
+    </table>
+  </emu-table>
+
+  <p>Once the values of [[Signifier]], [[IsLockFree1]], [[IsLockFree2]], and [[UseErrorCaptureStackTraceDataProperty]] have been observed by any agent in the agent cluster they cannot change.</p>
+</emu-clause>
+
+<emu-clause id="sec-agent-clusters">
+  <h1>Agent Clusters</h1>
+
+  <p>All agents within a cluster must have the same value for the [[UseErrorCaptureStackTraceDataProperty]] field in their respective Agent Records.</p>
+</emu-clause>
+
 <emu-clause id="sec-fundamental-objects" number="20">
   <h1>Fundamental Objects</h1>
 
@@ -34,9 +63,10 @@ markEffects: true
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Perform an implementation-defined choice of either:
+          1. Let _useErrorCaptureStackTraceDataProperty_ be the value of the [[UseErrorCaptureStackTraceDataProperty]] field of the surrounding agent's Agent Record.
+          1. If _useErrorCaptureStackTraceDataProperty_ is *true*, then
             1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
-          1. Or:
+          1. Else,
             1. If ? IsExtensible( _error_ ) is *false*, throw a *TypeError* exception.
             1. Let _name_ be an implementation-defined name.
             1. ! PrivateFieldAdd( _error_, _name_, _string_).

--- a/spec.emu
+++ b/spec.emu
@@ -15,16 +15,21 @@ markEffects: true
   <p></p>
 </emu-intro>
 
-<emu-clause id="sec-agents">
-  <h1>Agents</h1>
-
-  <emu-table id="table-agent-record" caption="Agent Record Fields">
+<emu-clause id="sec-code-realms">
+  <h1>Realms</h1>
+  <emu-table id="table-realm-record-fields" caption="Realm Record Fields" oldids="table-21">
     <table>
       <thead>
         <tr>
-          <th>Field Name</th>
-          <th>Value</th>
-          <th>Meaning</th>
+          <th>
+            Field Name
+          </th>
+          <th>
+            Value
+          </th>
+          <th>
+            Meaning
+          </th>
         </tr>
       </thead>
       <tr>
@@ -34,14 +39,6 @@ markEffects: true
       </tr>
     </table>
   </emu-table>
-
-  <p>Once the values of [[Signifier]], [[IsLockFree1]], [[IsLockFree2]], and [[ErrorCaptureStackTraceStrategy]] have been observed by any agent in the agent cluster they cannot change.</p>
-</emu-clause>
-
-<emu-clause id="sec-agent-clusters">
-  <h1>Agent Clusters</h1>
-
-  <p>All agents within a cluster must have the same value for the [[ErrorCaptureStackTraceStrategy]] field in their respective Agent Records.</p>
 </emu-clause>
 
 <emu-clause id="sec-fundamental-objects" number="20">
@@ -54,29 +51,28 @@ markEffects: true
       <h1>Properties of the Error Constructor</h1>
 
       <emu-clause id="sec-error.capturestacktrace">
-        <h1>Error.captureStackTrace ( _error_ [ , _constructor_ ] )</h1>
+        <h1>Error.captureStackTrace ( _O_ [ , _limit_ ] )</h1>
         <emu-alg>
-          1. If _error_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_constructor_) is *true*, then
+          1. If _O_ is not an Object, throw a *TypeError* exception.
+          1. If IsCallable(_limit_) is *true*, then
             1. Let _string_ be an implementation-defined string that represents the current stack trace, with all stack
-               frames above the topmost call to _constructor_, including that call, omitted from the stack trace.
+               frames above the topmost call to _limit_, including that call, omitted from the stack trace.
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Let _strategy_ be the value of the [[ErrorCaptureStackTraceStrategy]] field of the surrounding agent's Agent Record.
+          1. Let _strategy_ be the value of the [[ErrorCaptureStackTraceStrategy]] field of the current Realm Record.
           1. If _strategy_ is ~data-property~, then
-            1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
+            1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
           1. Else,
             1. Assert: _strategy_ is ~accessor~.
-            1. If ? IsExtensible(_error_) is *false*, throw a *TypeError* exception.
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
               1. Return NormalCompletion(_string_).
             1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, "", « »).
-            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _error_ and performs the following steps when called:
-              1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, *null*, *"stack"*, _value_).
+            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _O_ and performs the following steps when called:
+              1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _value_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
               1. Return NormalCompletion(*undefined*).
             1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, "", « »).
-            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: false, [[Configurable]]: true }).
+            1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -66,13 +66,13 @@ markEffects: true
             1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
           1. Else,
             1. Assert: _strategy_ is ~accessor~.
-            1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
-              1. Return NormalCompletion(_string_).
-            1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, "", « »).
-            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _O_ and performs the following steps when called:
-              1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _value_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
+            1. Let _captureStackSymbol_ be an implementation-defined Symbol value.
+            1. Perform ? DefinePropertyOrThrow(_O_, _captureStackSymbol_, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
+            1. Let _getter_ be a built-in function that takes no arguments and performs the following steps when called:
+              1. Return ? Get(*this* value, _captureStackSymbol_).
+            1. Let _setter_ be a built-in function that takes an argument _value_ and performs the following steps when called:
+              1. Perform ? DefinePropertyOrThrow(*this* value, *"stack"*, PropertyDescriptor { [[Value]]: _value_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
               1. Return NormalCompletion(*undefined*).
-            1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, "", « »).
             1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -66,13 +66,13 @@ markEffects: true
             1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
           1. Else,
             1. Assert: _strategy_ is ~accessor~.
-            1. Let _captureStackSymbol_ be an implementation-defined Symbol value.
-            1. Perform ? DefinePropertyOrThrow(_O_, _captureStackSymbol_, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
-            1. Let _getter_ be a built-in function that takes no arguments and performs the following steps when called:
-              1. Return ? Get(*this* value, _captureStackSymbol_).
-            1. Let _setter_ be a built-in function that takes an argument _value_ and performs the following steps when called:
-              1. Perform ? DefinePropertyOrThrow(*this* value, *"stack"*, PropertyDescriptor { [[Value]]: _value_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
+            1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
+              1. Return NormalCompletion(_string_).
+            1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, "", « »).
+            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _O_ and performs the following steps when called:
+              1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Value]]: _value_, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
               1. Return NormalCompletion(*undefined*).
+            1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, "", « »).
             1. Perform ? DefinePropertyOrThrow(_O_, *"stack"*, PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -34,7 +34,13 @@ markEffects: true
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_).
+          1. Perform an implementation-defined choice of either:
+            1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
+          1. Or:
+            1. If ? IsExtensible( _error_ ) is *false*, throw a *TypeError* exception.
+            1. Let _name_ be an implementation-defined name.
+            1. ! PrivateFieldAdd( _error_, _name_, _string_).
+            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: ? PrivateGet( _error_, _name_ ), [[Set]]: ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)., [[Enumerable]]: true, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -29,19 +29,19 @@ markEffects: true
       </thead>
       <tr>
         <td>[[ErrorCaptureStackTraceStrategy]]</td>
-        <td>DATAPROPERTY or ACCESSOR</td>
+        <td>~data-property~ or ~accessor~</td>
         <td>Whether to use a data property or an accessor property for the "stack" property installed by Error.captureStackTrace.</td>
       </tr>
     </table>
   </emu-table>
 
-  <p>Once the values of [[Signifier]], [[IsLockFree1]], [[IsLockFree2]], and [[UseErrorCaptureStackTraceDataProperty]] have been observed by any agent in the agent cluster they cannot change.</p>
+  <p>Once the values of [[Signifier]], [[IsLockFree1]], [[IsLockFree2]], and [[ErrorCaptureStackTraceStrategy]] have been observed by any agent in the agent cluster they cannot change.</p>
 </emu-clause>
 
 <emu-clause id="sec-agent-clusters">
   <h1>Agent Clusters</h1>
 
-  <p>All agents within a cluster must have the same value for the [[UseErrorCaptureStackTraceDataProperty]] field in their respective Agent Records.</p>
+  <p>All agents within a cluster must have the same value for the [[ErrorCaptureStackTraceStrategy]] field in their respective Agent Records.</p>
 </emu-clause>
 
 <emu-clause id="sec-fundamental-objects" number="20">
@@ -64,10 +64,10 @@ markEffects: true
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
           1. Let _strategy_ be the value of the [[ErrorCaptureStackTraceStrategy]] field of the surrounding agent's Agent Record.
-          1. If _strategy_ is DATAPROPERTY, then
+          1. If _strategy_ is ~data-property~, then
             1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
           1. Else,
-            1. Assert: _strategy_ is ACCESSOR.
+            1. Assert: _strategy_ is ~accessor~.
             1. If ? IsExtensible(_error_) is *false*, throw a *TypeError* exception.
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
               1. Return NormalCompletion(_string_).

--- a/spec.emu
+++ b/spec.emu
@@ -28,8 +28,8 @@ markEffects: true
         </tr>
       </thead>
       <tr>
-        <td>[[UseErrorCaptureStackTraceDataProperty]]</td>
-        <td>a Boolean</td>
+        <td>[[ErrorCaptureStackTraceStrategy]]</td>
+        <td>DATAPROPERTY or ACCESSOR</td>
         <td>Whether to use a data property or an accessor property for the "stack" property installed by Error.captureStackTrace.</td>
       </tr>
     </table>
@@ -63,18 +63,20 @@ markEffects: true
             1. NOTE: This can be used to hide implementation details on the stack trace that aren't useful to user.
           1. Else,
             1. Let _string_ be an implementation-defined string that represents the current stack trace.
-          1. Let _useErrorCaptureStackTraceDataProperty_ be the value of the [[UseErrorCaptureStackTraceDataProperty]] field of the surrounding agent's Agent Record.
-          1. If _useErrorCaptureStackTraceDataProperty_ is *true*, then
+          1. Let _strategy_ be the value of the [[ErrorCaptureStackTraceStrategy]] field of the surrounding agent's Agent Record.
+          1. If _strategy_ is DATAPROPERTY, then
             1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)..
           1. Else,
-            1. If ? IsExtensible( _error_ ) is *false*, throw a *TypeError* exception.
-            1. Let getterClosure be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
+            1. Assert: _strategy_ is ACCESSOR.
+            1. If ? IsExtensible(_error_) is *false*, throw a *TypeError* exception.
+            1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _string_ and performs the following steps when called:
               1. Return NormalCompletion(_string_).
-            1. Let getter be CreateBuiltinFunction(getterClosure, 0, "", « »).
-            1. Let setterClosure be a new Abstract Closure with parameters (_value_) that captures _error_ and performs the following steps when called:
-              1. Perform ! SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _value_).
-            1. Let setter be CreateBuiltinFunction(setterClosure, 1, "", « »).
-            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: getter, [[Set]]: setter, [[Enumerable]]: false, [[Configurable]]: true }).
+            1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, "", « »).
+            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _error_ and performs the following steps when called:
+              1. Perform ? SetterThatIgnoresPrototypeProperties(_error_, *null*, *"stack"*, _value_).
+              1. Return NormalCompletion(*undefined*).
+            1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, "", « »).
+            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -40,7 +40,7 @@ markEffects: true
             1. If ? IsExtensible( _error_ ) is *false*, throw a *TypeError* exception.
             1. Let _name_ be an implementation-defined name.
             1. ! PrivateFieldAdd( _error_, _name_, _string_).
-            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: ? PrivateGet( _error_, _name_ ), [[Set]]: ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)., [[Enumerable]]: true, [[Configurable]]: true }).
+            1. Perform ! OrdinaryDefineOwnProperty(_error_, *"stack"*, PropertyDescriptor { [[Get]]: ? PrivateGet( _error_, _name_ ), [[Set]]: ? SetterThatIgnoresPrototypeProperties(_error_, OrdinaryObjectCreate(*null*), *"stack"*, _string_)., [[Enumerable]]: false, [[Configurable]]: true }).
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This is an attempt to reflect web reality and allow an implementation-defined choice of whether to use a property (like SpiderMonkey and JSC) or accessors (like V8). Allowing an implementation-defined choice came up in a couple of conversations, including https://github.com/tc39/proposal-error-capturestacktrace/issues/1#issuecomment-3133604399.

The accessor sets a private property, which is what V8 currently does. If I recall correctly, the objection to a private property came from JSC, but if we go with this direction, JSC could continue to use a data property, so hopefully this won't be problematic. If it turns out to be objectionable, we could instead use closures, as was suggested by bakkot, see https://github.com/tc39/proposal-error-capturestacktrace/issues/1#issuecomment-3133528880.